### PR TITLE
refactor: remove leftover pwa code

### DIFF
--- a/pwa-assets.config.js
+++ b/pwa-assets.config.js
@@ -1,6 +1,0 @@
-import { defineConfig, minimalPreset as preset } from "@vite-pwa/assets-generator/config";
-
-export default defineConfig({
-    preset,
-    images: ["public/img/icon_app.png"],
-});


### PR DESCRIPTION
I'm still not sure why pwa code was removed, there is no alternative yet and I and others still use it with the offline version.